### PR TITLE
Add clear_expired_entries to store

### DIFF
--- a/spec/marten_db_session/store_spec.cr
+++ b/spec/marten_db_session/store_spec.cr
@@ -81,6 +81,7 @@ describe MartenDBSession::Store do
       store.clear_expired_entries
 
       MartenDBSession::Entry.all.size.should eq 1
+      MartenDBSession::Entry.first!.key.should eq "not_expired_key"
     end
   end
 

--- a/spec/marten_db_session/store_spec.cr
+++ b/spec/marten_db_session/store_spec.cr
@@ -54,12 +54,6 @@ describe MartenDBSession::Store do
 
       store = MartenDBSession::Store.new("testkey")
 
-      time = Time.local(Marten.settings.time_zone)
-      Timecop.freeze(time) do
-        store["test"] = "xyz"
-        store.save
-      end
-
       MartenDBSession::Entry.all.size.should eq 1
 
       store.clear_expired_entries

--- a/src/marten_db_session/store.cr
+++ b/src/marten_db_session/store.cr
@@ -32,6 +32,10 @@ module MartenDBSession
       persist_session_data(session_hash)
     end
 
+    def clear_expired_entries : Nil
+      Entry.filter(expires__let: Time.local(Marten.settings.time_zone)).delete
+    end
+
     private getter entry
 
     private def entry!

--- a/src/marten_db_session/store.cr
+++ b/src/marten_db_session/store.cr
@@ -33,7 +33,7 @@ module MartenDBSession
     end
 
     def clear_expired_entries : Nil
-      Entry.filter(expires__let: Time.local(Marten.settings.time_zone)).delete
+      Entry.filter(expires__lt: Time.local(Marten.settings.time_zone)).delete
     end
 
     private getter entry


### PR DESCRIPTION
Follow-Up to [marten#107](https://github.com/martenframework/marten/pull/107)

Implements `clear_expired_entries` for `MartenDBSession::Store`
